### PR TITLE
Fix an erorr because :untagged is used for http redirect limit value

### DIFF
--- a/bin/addic7ed
+++ b/bin/addic7ed
@@ -102,7 +102,7 @@ options[:filenames].each do |filename|
       puts "    #{ep.best_subtitle(options[:language])}"
     end
     unless options[:nodownload]
-      ep.download_best_subtitle!(options[:language], options[:untagged])
+      ep.download_best_subtitle!(options[:language])
       puts "New subtitle downloaded for #{filename}.\nEnjoy your show :-)".gsub(/^/, options[:verbose] ? '  ' : '') unless options[:quiet]
     end
   rescue Addic7ed::InvalidFilename


### PR DESCRIPTION
```
$> addic7ed -u -l en movie.mp4
/home/florent/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/addic7ed-0.4.0/lib/addic7ed/episode.rb:33:in `download_best_subtitle!': undefined method `>' for true:TrueClass (NoMethodError)
	from /home/florent/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/addic7ed-0.4.0/bin/addic7ed:105:in `block in <top (required)>'
	from /home/florent/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/addic7ed-0.4.0/bin/addic7ed:77:in `each'
	from /home/florent/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/addic7ed-0.4.0/bin/addic7ed:77:in `<top (required)>'
	from /home/florent/.rbenv/versions/2.2.0/bin/addic7ed:23:in `load'
	from /home/florent/.rbenv/versions/2.2.0/bin/addic7ed:23:in `<main>'
```