### PR TITLE
Checking the comment field for compatibility

### DIFF
--- a/lib/addic7ed/parser.rb
+++ b/lib/addic7ed/parser.rb
@@ -44,7 +44,8 @@ module Addic7ed
         status:    extract_status(sub_node),
         url:       extract_url(sub_node),
         source:    extract_source(sub_node),
-        downloads: extract_downloads(sub_node)
+        downloads: extract_downloads(sub_node),
+        comment:   extract_comment(sub_node)
       )
     end
 
@@ -81,6 +82,12 @@ module Addic7ed
       downloads_node = sub_node.css('tr:nth-child(4) td.newsDate').first
       raise Addic7ed::ParsingError unless downloads_node
       /(?<downloads>\d*) Downloads/.match(downloads_node.content)[:downloads]
+    end
+
+    def extract_comment(sub_node)
+        comment_node = sub_node.css('tr:nth-child(2) td.newsDate').first
+        raise Addic7ed::ParsingError unless comment_node
+        comment_node.content.gsub(/<img[^>]+\>/i, "")
     end
 
   end

--- a/lib/addic7ed/subtitle.rb
+++ b/lib/addic7ed/subtitle.rb
@@ -61,16 +61,25 @@ module Addic7ed
     end
 
     def is_compatible_with?(other_version)
-      version_compatible = self.version == other_version ||
-      COMPATIBILITY_720P[self.version] == other_version ||
-      COMPATIBILITY_720P[other_version] == self.version
+      generally_compatible_with?(other_version) ||
+      commented_as_compatible_with?(other_version)
+    end
 
-      comment_compatible = self.comment.include? other_version.downcase
-      if COMPATIBILITY_720P[other_version]
-        comment_compatible ||= self.comment.include? COMPATIBILITY_720P[other_version].downcase
-      end
+    def generally_compatible_with?(other_version)
+        self.version == other_version ||
+        COMPATIBILITY_720P[self.version] == other_version ||
+        COMPATIBILITY_720P[other_version] == self.version
+    end
 
-      version_compatible || comment_compatible
+    def commented_as_compatible_with?(other_version)
+        compatibility = COMPATIBILITY_720P[other_version]
+
+        comment_compatible = self.comment.include?(other_version.downcase)
+        if compatibility
+            comment_compatible ||= self.comment.include?(compatibility.downcase)
+        end
+
+        comment_compatible
     end
 
     def is_more_popular_than?(other_subtitle)

--- a/lib/addic7ed/subtitle.rb
+++ b/lib/addic7ed/subtitle.rb
@@ -1,7 +1,7 @@
 module Addic7ed
   class Subtitle
 
-    attr_reader :version, :language, :status, :via, :downloads
+    attr_reader :version, :language, :status, :via, :downloads, :comment
     attr_accessor :url
 
     def initialize(options = {})
@@ -11,7 +11,9 @@ module Addic7ed
       @url       = options[:url]
       @via       = options[:via]
       @downloads = options[:downloads].to_i || 0
+      @comment   = options[:comment]
       normalize_version!
+      normalize_comment!
     end
 
     def to_s
@@ -53,10 +55,22 @@ module Addic7ed
       @version.upcase!
     end
 
+    def normalize_comment!
+      @comment ||= ""
+      @comment.downcase!
+    end
+
     def is_compatible_with?(other_version)
-      self.version == other_version ||
+      version_compatible = self.version == other_version ||
       COMPATIBILITY_720P[self.version] == other_version ||
       COMPATIBILITY_720P[other_version] == self.version
+
+      comment_compatible = self.comment.include? other_version.downcase
+      if COMPATIBILITY_720P[other_version]
+        comment_compatible ||= self.comment.include? COMPATIBILITY_720P[other_version].downcase
+      end
+
+      version_compatible || comment_compatible
     end
 
     def is_more_popular_than?(other_subtitle)

--- a/spec/lib/addic7ed/subtitle_spec.rb
+++ b/spec/lib/addic7ed/subtitle_spec.rb
@@ -57,7 +57,7 @@ describe Addic7ed::Subtitle, "#to_s" do
 end
 
 describe Addic7ed::Subtitle, "#works_for?" do
-  let(:subtitle) { Addic7ed::Subtitle.new(version: "DIMENSION") }
+  let(:subtitle) { Addic7ed::Subtitle.new(version: "DIMENSION", comment: "Works with IMMERSE") }
 
   context "when it is incomplete" do
     before { allow(subtitle).to receive(:is_completed?).and_return(false) }
@@ -80,6 +80,18 @@ describe Addic7ed::Subtitle, "#works_for?" do
 
     it "returns false given an incompatible version" do
       expect(subtitle.works_for? "EVOLVE").to be false
+    end
+
+    it "returns true given the same version as comment" do
+      expect(subtitle.works_for? "IMMERSE").to be true
+    end
+
+    it "returns true given a compatible version as comment" do
+      expect(subtitle.works_for? "ASAP").to be true
+    end
+
+    it "returns false given an incompatible version as comment" do
+      expect(subtitle.works_for? "KILLERS").to be false
     end
   end
 end


### PR DESCRIPTION
The comment field of a subtitle is often used to list other compatible versions, and I added a small check for this.