### PR TITLE
Add support of Addic7ed defining multiple versions compatibility

### DIFF
--- a/lib/addic7ed.rb
+++ b/lib/addic7ed.rb
@@ -1,5 +1,7 @@
 require 'addic7ed/version'
 require 'addic7ed/common'
+require 'addic7ed/services/addic7ed_version_normalizer'
+require 'addic7ed/services/addic7ed_comment_normalizer'
 require 'addic7ed/errors'
 require 'addic7ed/show_list'
 require 'addic7ed/video_file'

--- a/lib/addic7ed/parser.rb
+++ b/lib/addic7ed/parser.rb
@@ -58,7 +58,7 @@ module Addic7ed
     def extract_version(sub_node)
       version_node = sub_node.css('.NewsTitle').first
       raise Addic7ed::ParsingError unless version_node
-      version_node.content.gsub(/ \nVersion /, '').gsub(/,.*/, '')
+      version_node.content
     end
 
     def extract_language(sub_node)
@@ -101,6 +101,5 @@ module Addic7ed
         raise Addic7ed::ParsingError unless comment_node
         comment_node.content.gsub(/<img[^>]+\>/i, "")
     end
-
   end
 end

--- a/lib/addic7ed/services/addic7ed_comment_normalizer.rb
+++ b/lib/addic7ed/services/addic7ed_comment_normalizer.rb
@@ -1,0 +1,19 @@
+module Addic7ed
+  class Addic7edCommentNormalizer
+    attr_reader :comment
+
+    def initialize(comment)
+      @comment = comment || ""
+    end
+
+    def self.call(comment)
+      new(comment).call
+    end
+
+    def call
+      comment.downcase
+    end
+  end
+
+private
+end

--- a/lib/addic7ed/services/addic7ed_version_normalizer.rb
+++ b/lib/addic7ed/services/addic7ed_version_normalizer.rb
@@ -1,0 +1,24 @@
+module Addic7ed
+  class Addic7edVersionNormalizer
+    attr_reader :version
+
+    def initialize(version)
+      @version = version || ""
+    end
+
+    def self.call(version)
+      new(version).call
+    end
+
+    def call
+      version.
+        gsub(/[[:space:]]/, "").
+        upcase.
+        gsub(/,[\d\. ]+MBS$/, '').
+        gsub(/(^VERSION *|720P|1080P|HDTV|PROPER|RERIP|INTERNAL|X\.?264)/, '').
+        gsub(/[- \.]/, '')
+    end
+  end
+
+private
+end

--- a/lib/addic7ed/subtitle.rb
+++ b/lib/addic7ed/subtitle.rb
@@ -5,14 +5,14 @@ module Addic7ed
     attr_accessor :url
 
     def initialize(options = {})
-      @version   = normalize_version(options[:version])
+      @version   = Addic7edVersionNormalizer.call(options[:version])
       @language  = options[:language]
       @status    = options[:status]
       @url       = options[:url]
       @via       = options[:via]
       @hi        = options[:hi]
       @downloads = options[:downloads].to_i || 0
-      @comment   = normalize_comment(options[:comment])
+      @comment   = Addic7edCommentNormalizer.call(options[:comment])
     end
 
     def to_s
@@ -42,23 +42,16 @@ module Addic7ed
 
   protected
 
-    def normalize_version(version)
-      (version || "").
-        gsub(/(^Version *|720p|1080p|hdtv|proper|rerip|internal|x\.?264)/i, '').
-        gsub(/^[- \.]*/, '').gsub(/[- \.]*$/, '').
-        upcase
-    end
-
-    def normalize_comment(comment)
-      (comment || "").downcase
-    end
-
     def is_compatible_with?(other_version)
-      generally_compatible_with?(other_version) || commented_as_compatible_with?(other_version)
+      defined_as_compatible_with(other_version) || generally_compatible_with?(other_version) || commented_as_compatible_with?(other_version)
+    end
+
+    def defined_as_compatible_with(other_version)
+      version.split(",").include? other_version
     end
 
     def generally_compatible_with?(other_version)
-      version == other_version || COMPATIBILITY_720P[version] == other_version || COMPATIBILITY_720P[other_version] == version
+      COMPATIBILITY_720P[version] == other_version || COMPATIBILITY_720P[other_version] == version
     end
 
     def commented_as_compatible_with?(other_version)

--- a/spec/lib/addic7ed/services/addic7ed_comment_normalizer_spec.rb
+++ b/spec/lib/addic7ed/services/addic7ed_comment_normalizer_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+require "./lib/addic7ed"
+
+describe Addic7ed::Addic7edCommentNormalizer do
+  def normalized_comment(comment)
+    described_class.call(comment)
+  end
+
+  it "downcases everything" do
+    expect(normalized_comment("DiMENSiON")).to eq "dimension"
+  end
+end

--- a/spec/lib/addic7ed/services/addic7ed_version_normalizer_spec.rb
+++ b/spec/lib/addic7ed/services/addic7ed_version_normalizer_spec.rb
@@ -1,0 +1,73 @@
+require "spec_helper"
+require "./lib/addic7ed"
+
+describe Addic7ed::Addic7edVersionNormalizer do
+  def normalized_version(version)
+    described_class.call(version)
+  end
+
+  it "upcases everything" do
+    expect(normalized_version("DiMENSiON")).to eq "DIMENSION"
+  end
+
+  it "removes white spaces and line breaks and non-breaking spaces" do
+    expect(normalized_version(" \n DIMENSION \u00a0 ")).to eq "DIMENSION"
+  end
+
+  it "removes the filesize" do
+    expect(normalized_version("DIMENSION, 0.00 MBs")).to eq "DIMENSION"
+  end
+
+  it "removes heading or trailing dots" do
+    expect(normalized_version(".DIMENSION.")).to eq "DIMENSION"
+  end
+
+  it "removes heading or trailing whitespaces" do
+    expect(normalized_version(" DIMENSION ")).to eq "DIMENSION"
+  end
+
+  it "removes heading or trailing dashes" do
+    expect(normalized_version("-DIMENSION-")).to eq "DIMENSION"
+  end
+
+  it "removes '720p' tag" do
+    expect(normalized_version("720P DIMENSION")).to eq "DIMENSION"
+  end
+
+  it "removes '1080p' tag" do
+    expect(normalized_version("1080P DIMENSION")).to eq "DIMENSION"
+  end
+
+  it "removes 'HDTV' tag" do
+    expect(normalized_version("HDTV DIMENSION")).to eq "DIMENSION"
+  end
+
+  it "removes 'x264' tag" do
+    expect(normalized_version("X264 DIMENSION")).to eq "DIMENSION"
+    expect(normalized_version("X.264 DIMENSION")).to eq "DIMENSION"
+  end
+
+  it "removes 'PROPER' tag" do
+    expect(normalized_version("PROPER DIMENSION")).to eq "DIMENSION"
+  end
+
+  it "removes 'RERIP' tag" do
+    expect(normalized_version("RERIP DIMENSION")).to eq "DIMENSION"
+  end
+
+  it "removes 'INTERNAL' tag" do
+    expect(normalized_version("INTERNAL DIMENSION")).to eq "DIMENSION"
+  end
+
+  it "removes the 'Version' prefix" do
+    expect(normalized_version("Version DIMENSION")).to eq "DIMENSION"
+  end
+
+  it "removes combined tags" do
+    expect(normalized_version("Version 720P PROPER X264 HDTV DIMENSION")).to eq "DIMENSION"
+  end
+
+  it "supports multiple concatenated versions" do
+    expect(normalized_version("-TLA, -FoV")).to eq "TLA,FOV"
+  end
+end

--- a/spec/lib/addic7ed/subtitle_spec.rb
+++ b/spec/lib/addic7ed/subtitle_spec.rb
@@ -1,62 +1,20 @@
 require "spec_helper"
 require "./lib/addic7ed"
 
-describe Addic7ed::Subtitle, "#normalize_version!" do
-  def normalized_version(version)
-    Addic7ed::Subtitle.new(version: version).version
+describe Addic7ed::Subtitle, "#initialize" do
+  let(:version) { "Version DIMENSiON" }
+  let(:comment) { "Works for LOL" }
+
+  subject { described_class.new(version: version, comment: comment) }
+
+  it "normalizes Addic7ed version" do
+    expect(Addic7ed::Addic7edVersionNormalizer).to receive(:call).with(version)
+    subject
   end
 
-  it "upcases everything" do
-    expect(normalized_version("DiMENSiON")).to eq 'DIMENSION'
-  end
-
-  it "removes heading or trailing dots" do
-    expect(normalized_version(".DIMENSION.")).to eq 'DIMENSION'
-  end
-
-  it "removes heading or trailing whitespaces" do
-    expect(normalized_version(" DIMENSION ")).to eq 'DIMENSION'
-  end
-
-  it "removes heading or trailing dashes" do
-    expect(normalized_version("-DIMENSION-")).to eq 'DIMENSION'
-  end
-
-  it "removes '720p' tag" do
-    expect(normalized_version("720P DIMENSION")).to eq 'DIMENSION'
-  end
-
-  it "removes '1080p' tag" do
-    expect(normalized_version("1080P DIMENSION")).to eq 'DIMENSION'
-  end
-
-  it "removes 'HDTV' tag" do
-    expect(normalized_version("HDTV DIMENSION")).to eq 'DIMENSION'
-  end
-
-  it "removes 'x264' tag" do
-    expect(normalized_version("X264 DIMENSION")).to eq 'DIMENSION'
-    expect(normalized_version("X.264 DIMENSION")).to eq 'DIMENSION'
-  end
-
-  it "removes 'PROPER' tag" do
-    expect(normalized_version("PROPER DIMENSION")).to eq 'DIMENSION'
-  end
-
-  it "removes 'RERIP' tag" do
-    expect(normalized_version("RERIP DIMENSION")).to eq 'DIMENSION'
-  end
-
-  it "removes 'INTERNAL' tag" do
-    expect(normalized_version("INTERNAL DIMENSION")).to eq 'DIMENSION'
-  end
-
-  it "removes the 'Version' prefix" do
-    expect(normalized_version("Version DIMENSION")).to eq 'DIMENSION'
-  end
-
-  it "removes combined tags" do
-    expect(normalized_version("Version 720P PROPER X264 HDTV DIMENSION")).to eq "DIMENSION"
+  it "normalizes Addic7ed comment" do
+    expect(Addic7ed::Addic7edCommentNormalizer).to receive(:call).with(comment)
+    subject
   end
 end
 
@@ -123,6 +81,19 @@ describe Addic7ed::Subtitle, "#works_for?" do
 
       it "returns false" do
         expect(subtitle.works_for? "IMMERSE").to be false
+      end
+    end
+
+    context "when it has multiple versions" do
+      let(:subtitle) { Addic7ed::Subtitle.new(version: "FOV,TLA") }
+
+      it "returns true if it works for one of them" do
+        expect(subtitle.works_for? "TLA").to be true
+        expect(subtitle.works_for? "FOV").to be true
+      end
+
+      it "returns false when none of them work" do
+        expect(subtitle.works_for? "LOL").to be false
       end
     end
   end


### PR DESCRIPTION
Stuff like that:
![screenshot-www addic7ed com 2016-06-11 13-11-48](https://cloud.githubusercontent.com/assets/1447321/15984271/28c81f16-2fd6-11e6-8aea-1f9f946854c9.png)


Also moves version(s) detection/normalization to a separate service object.